### PR TITLE
docs(readme, package.json): fixed incorrect git urls in docs and package config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install @tocharian/mcp-server-kibana
 
 ### Alternative: From Source
 ```bash
-git clone https://github.com/TocharinOU/mcp-server-kibana.git
+git clone https://github.com/TocharianOU/mcp-server-kibana.git
 cd mcp-server-kibana
 npm install
 npm run build
@@ -171,7 +171,7 @@ Configure the server via environment variables:
 ## 📦 Package Information
 
 - **NPM Package**: [@tocharian/mcp-server-kibana](https://www.npmjs.com/package/@tocharian/mcp-server-kibana)
-- **GitHub Repository**: [TocharinOU/mcp-server-kibana](https://github.com/TocharinOU/mcp-server-kibana)
+- **GitHub Repository**: [TocharianOU/mcp-server-kibana](https://github.com/TocharianOU/mcp-server-kibana)
 - **Node.js**: >= 18.0.0
 - **Package Size**: ~685KB (6.4MB unpacked)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -106,7 +106,7 @@ npm install @tocharian/mcp-server-kibana
 
 ### 替代方案：从源码安装
 ```bash
-git clone https://github.com/TocharinOU/mcp-server-kibana.git
+git clone https://github.com/TocharianOU/mcp-server-kibana.git
 cd mcp-server-kibana
 npm install
 npm run build
@@ -240,7 +240,7 @@ npm run inspector
 ## 📦 包信息
 
 - **NPM 包**: [@tocharian/mcp-server-kibana](https://www.npmjs.com/package/@tocharian/mcp-server-kibana)
-- **GitHub 仓库**: [TocharinOU/mcp-server-kibana](https://github.com/TocharinOU/mcp-server-kibana)
+- **GitHub 仓库**: [TocharianOU/mcp-server-kibana](https://github.com/TocharianOU/mcp-server-kibana)
 - **Node.js 要求**: >= 18.0.0
 - **包大小**: ~685KB (解压后 6.4MB)
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "bin": {
     "mcp-server-kibana": "./dist/index.js"
   },
-  "repository": "https://github.com/TocharinOU/mcp-server-kibana",
-  "bugs": "https://github.com/TocharinOU/mcp-server-kibana/issues",
-  "homepage": "https://github.com/TocharinOU/mcp-server-kibana",
+  "repository": "https://github.com/TocharianOU/mcp-server-kibana",
+  "bugs": "https://github.com/TocharianOU/mcp-server-kibana/issues",
+  "homepage": "https://github.com/TocharianOU/mcp-server-kibana",
   "keywords": [
     "kibana",
     "mcp",


### PR DESCRIPTION
I noticed that the quick start links led to non-existent pages due to the github username being different (TocharinOU vs TocharianOU). I fixed a few instances of this incorrect URL, but I opted to leave a couple examples of the TocharinOU name, since it's possible the author prefers that spelling. The github urls are incorrect, though, for sure, so they needed fixing.