### PR TITLE
Kibana 9 internal APIs access fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -40,7 +40,8 @@ function createKibanaClient(config: KibanaConfig): KibanaClient {
     timeout: 60000, // 60 seconds
     headers: {
       'Content-Type': 'application/json',
-      'kbn-xsrf': 'true'
+      'kbn-xsrf': 'true',
+      'x-elastic-internal-origin': 'kibana'
     },
   };
 


### PR DESCRIPTION
## Add `x-elastic-internal-origin` header for Kibana 9 compatibility

Kibana 9.x now requires the `x-elastic-internal-origin: kibana` header on all requests to `/internal/*` endpoints — without it, those calls get a 400 (we're calling these via `execute_kb_api` tool)

This adds the header to the base axios config so it's sent on every request. It's safe for older Kibana versions (they just ignore it), and the Kibana team actually [recommends sending it on all requests](https://github.com/elastic/kibana/issues/152287), not just internal ones

### Changes

- Added `'x-elastic-internal-origin': 'kibana'` to default headers in `index.ts`

### Testing

Was tested on Kibana 9.3. Wasn't tested on 8.x, should be safe but would appreciate if someone tests it 🙏 
