### PR TITLE
fix: handle sub-path KIBANA_URL to prevent 401 on non-root Kibana installations

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,8 +35,15 @@ import { registerAnalysisTools } from "./src/analysis-tools.js";
 
 // Create Kibana client
 function createKibanaClient(config: KibanaConfig): KibanaClient {
+  // Extract origin and base path separately so that axios does not drop
+  // the sub-path when request URLs start with "/".
+  // e.g. KIBANA_URL = "https://host/_plugin/kibana"
+  //   → origin   = "https://host"
+  //   → basePath = "/_plugin/kibana"
+  const parsedUrl = new URL(config.url);
+  const basePath = parsedUrl.pathname.replace(/\/$/, ''); // e.g. "/_plugin/kibana" or ""
   const axiosConfig: any = {
-    baseURL: config.url,
+    baseURL: parsedUrl.origin,   // e.g. "https://host"
     timeout: 60000, // 60 seconds
     headers: {
       'Content-Type': 'application/json',
@@ -71,13 +78,15 @@ function createKibanaClient(config: KibanaConfig): KibanaClient {
     }
   }
 
-  // Dynamic URL transformation logic - support specifying space for each call
+  // Dynamic URL transformation logic - support specifying space for each call.
+  // Always prepend basePath so that sub-path installations (e.g. /_plugin/kibana)
+  // are handled correctly regardless of whether the request path starts with "/".
   const buildSpaceAwareUrl = (url: string, space?: string): string => {
     const targetSpace = space || config.defaultSpace;
     if (targetSpace && targetSpace !== 'default' && url.startsWith('/api/')) {
-      return `/s/${targetSpace}${url}`;
+      return `${basePath}/s/${targetSpace}${url}`;
     }
-    return url;
+    return `${basePath}${url}`;
   };
 
   const axiosInstance = axios.create(axiosConfig);


### PR DESCRIPTION
## Problem

When `KIBANA_URL` contains a sub-path (e.g. `https://host/_plugin/kibana` as used by **AWS OpenSearch Service**), all API tools except `get_status` return **401 Unauthorized**.

### Root cause

axios silently drops the path component of `baseURL` when request paths start with `/`:

```
baseURL = "https://host/_plugin/kibana"
GET /api/saved_objects/_find
→ actual request: https://host/api/saved_objects/_find  ❌
→ expected:       https://host/_plugin/kibana/api/saved_objects/_find  ✅
```

`get_status` accidentally works because `/api/status` is a public endpoint exposed at the domain root as well (no auth required).

Tracked in issue #10.

## Fix

Split `config.url` into `origin` + `basePath` at client creation time. Set `baseURL` to the origin only, and prepend `basePath` inside `buildSpaceAwareUrl` so every request carries the correct full path.

```ts
const parsedUrl = new URL(config.url);
const basePath = parsedUrl.pathname.replace(/\/$/, ''); // e.g. "/_plugin/kibana" or ""
const axiosConfig = {
  baseURL: parsedUrl.origin,   // "https://host"
  ...
};

const buildSpaceAwareUrl = (url, space) => {
  ...
  return `${basePath}${url}`;  // prepend sub-path on every call
};
```

When `KIBANA_URL` has no sub-path (e.g. `https://host`), `basePath` is `""` so behaviour is **fully backward-compatible**.

## Testing

Verified against an AWS OpenSearch Service instance with `KIBANA_URL=https://<domain>/_plugin/kibana` — all tools now return correct responses instead of 401.